### PR TITLE
Unused variable

### DIFF
--- a/TwitterLivestreamSwift/Stores/TweetStore.swift
+++ b/TwitterLivestreamSwift/Stores/TweetStore.swift
@@ -71,7 +71,7 @@ class TweetStore {
     // handle upload
     let stateMerge = StateMerge(originalList:self.serverTweets, localState: self.localState)
     
-    TwitterClient.syncLocalState(StateMerge(originalList:serverTweets, localState: localState))
+    TwitterClient.syncLocalState(stateMerge)
       .then{ syncResult -> () in
         switch syncResult {
         case SyncResult.Success(let stateMergeResult):


### PR DESCRIPTION
I'm assuming that `stateMerge` was created to simplify reading the `syncLocalState` function call but it seems that it wasn't changed and the variable was hanging there unused.

Did not run this locally so feel free to disregard this if this wasn't the case.
